### PR TITLE
Save landing page in local storage on update

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { renderElements } from "./components/editor_components_renderer";
 import { PreviewCanvas } from "./components/preview_canvas";
 import "./App.css";
@@ -22,8 +22,10 @@ import { deleteElementHandler } from "./components/handlers/delete_element";
 import { moveElementHandler } from "./components/handlers/move_element";
 import { landingElementUpdater } from "./components/handlers/update_element";
 import { type LandingElement, type LandingPage } from "./components/types";
-
-const DEFAULT_PAGE: LandingPage = { elements: [] };
+import {
+	getInitialLandingPage,
+	saveLandingPage,
+} from "./components/landing_page_storage";
 
 function findElementById(page: LandingPage, elementId: string): LandingElement {
 	for (const element of page.elements) {
@@ -36,7 +38,13 @@ function findElementById(page: LandingPage, elementId: string): LandingElement {
 }
 
 function App() {
-	const [landingPage, setLandingPage] = useState<LandingPage>(DEFAULT_PAGE);
+	const [landingPage, setLandingPage] = useState<LandingPage>(
+		getInitialLandingPage(),
+	);
+
+	useEffect(() => {
+		saveLandingPage(landingPage);
+	}, [landingPage]);
 	const [settingsElementId, setSettingsElementId] = useState<string | null>(
 		null,
 	);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,8 +21,8 @@ import { createElementHandler } from "./components/handlers/create_element";
 import { deleteElementHandler } from "./components/handlers/delete_element";
 import { moveElementHandler } from "./components/handlers/move_element";
 import { landingElementUpdater } from "./components/handlers/update_element";
-import { type LandingElement, type LandingPage } from "./components/types";
 import * as landingPageStorage from "./components/landing_page_storage";
+import { type LandingElement, type LandingPage } from "./components/types";
 
 function findElementById(page: LandingPage, elementId: string): LandingElement {
 	for (const element of page.elements) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { renderElements } from "./components/editor_components_renderer";
 import { PreviewCanvas } from "./components/preview_canvas";
 import "./App.css";
@@ -22,10 +22,7 @@ import { deleteElementHandler } from "./components/handlers/delete_element";
 import { moveElementHandler } from "./components/handlers/move_element";
 import { landingElementUpdater } from "./components/handlers/update_element";
 import { type LandingElement, type LandingPage } from "./components/types";
-import {
-	getInitialLandingPage,
-	saveLandingPage,
-} from "./components/landing_page_storage";
+import * as landingPageStorage from "./components/landing_page_storage";
 
 function findElementById(page: LandingPage, elementId: string): LandingElement {
 	for (const element of page.elements) {
@@ -39,12 +36,14 @@ function findElementById(page: LandingPage, elementId: string): LandingElement {
 
 function App() {
 	const [landingPage, setLandingPage] = useState<LandingPage>(
-		getInitialLandingPage(),
+		landingPageStorage.getInitialLandingPage(),
 	);
 
-	useEffect(() => {
-		saveLandingPage(landingPage);
-	}, [landingPage]);
+	const updateLandingPage = (updated: LandingPage) => {
+		setLandingPage(updated);
+		landingPageStorage.saveLandingPage(updated);
+	};
+
 	const [settingsElementId, setSettingsElementId] = useState<string | null>(
 		null,
 	);
@@ -53,10 +52,10 @@ function App() {
 		setSettingsElementId(element.id);
 	};
 
-	const updater = landingElementUpdater(landingPage, setLandingPage);
-	const moveHandler = moveElementHandler(landingPage, setLandingPage);
-	const createElement = createElementHandler(landingPage, setLandingPage);
-	const deleteHandler = deleteElementHandler(landingPage, setLandingPage);
+	const updater = landingElementUpdater(landingPage, updateLandingPage);
+	const moveHandler = moveElementHandler(landingPage, updateLandingPage);
+	const createElement = createElementHandler(landingPage, updateLandingPage);
+	const deleteHandler = deleteElementHandler(landingPage, updateLandingPage);
 
 	return (
 		<div className="app-container">

--- a/src/components/landing_page_storage.ts
+++ b/src/components/landing_page_storage.ts
@@ -1,0 +1,24 @@
+import { type LandingPage } from "./types";
+
+const STORAGE_KEY = "landingPageState";
+const DEFAULT_PAGE: LandingPage = { elements: [] };
+
+export function getInitialLandingPage(): LandingPage {
+	try {
+		const stored = localStorage.getItem(STORAGE_KEY);
+		if (stored) {
+			return JSON.parse(stored);
+		}
+	} catch (error) {
+		console.error("Failed to load landing page from localStorage:", error);
+	}
+	return DEFAULT_PAGE;
+}
+
+export function saveLandingPage(landingPage: LandingPage): void {
+	try {
+		localStorage.setItem(STORAGE_KEY, JSON.stringify(landingPage));
+	} catch (error) {
+		console.error("Failed to save landing page to localStorage:", error);
+	}
+}


### PR DESCRIPTION
Теперь при обновлении состояния landing page новое значение сохраняется в Local Storage. При начале сессии в браузере как дефолтное значение теперь берется значение из local storage, а если его нет - берется дефолтное значение из кода.


https://github.com/user-attachments/assets/2de8a867-0bc1-4fa2-b218-d7e16915510d

